### PR TITLE
[v2] Redirect anti-harassment page

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ app.use(webpackDevMiddleware(compiler, {
   historyApiFallback: true,
 }));
  
-app.get('/anti-harrassment', function(req, res) {
+app.get('/anti-harassment', function(req, res) {
   res.redirect('/#/policy');
 })
 

--- a/server.js
+++ b/server.js
@@ -18,6 +18,10 @@ app.use(webpackDevMiddleware(compiler, {
   historyApiFallback: true,
 }));
  
+app.get('/anti-harrassment', function(req, res) {
+  res.redirect('/#/policy');
+})
+
 var server = app.listen(3000, function() {
   var host = server.address().address;
   var port = server.address().port;


### PR DESCRIPTION
Fixes: https://github.com/TechAtNYU/techatnyu.org/issues/14

Our harassment policy page currently lives here: http://techatnyu.org/anti-harassment, and we have many links that point to this specific URL. in v2 of the site where we are using React + ReactRouter, our paths would end up being http://techatnyu.org/#/[page], and not http://techatnyu.org/[page]

So I'm adding a server-side bypass that redirects to `/#/policy`, which is where our anti-harassment page lives in v2 so that people won't encounter a 404 when they click on our old url.

![ttt](https://user-images.githubusercontent.com/11889765/37946123-d0de65d8-3151-11e8-8aea-47b95263fdfc.gif)
